### PR TITLE
Improve lift metrics handling of zero base rates and NaNs

### DIFF
--- a/gosales/tests/test_phase3_metrics.py
+++ b/gosales/tests/test_phase3_metrics.py
@@ -1,9 +1,10 @@
 import numpy as np
-import pandas as pd
+import pytest
 
 from gosales.models.metrics import (
     compute_topk_threshold,
     compute_lift_at_k,
+    compute_weighted_lift_at_k,
     calibration_bins,
     calibration_mae,
 )
@@ -35,5 +36,39 @@ def test_lift_at_k_monotonic():
     scores = np.concatenate([np.linspace(0, 0.2, 90), np.linspace(0.8, 1.0, 10)])
     lift10 = compute_lift_at_k(y, scores, 10)
     assert lift10 > 1.0
+
+
+def test_lift_at_k_zero_base_nan_default():
+    y = np.zeros(50)
+    scores = np.linspace(0, 1, 50)
+    result = compute_lift_at_k(y, scores, 10)
+    assert np.isnan(result)
+
+
+def test_lift_at_k_zero_base_custom_default():
+    y = np.zeros(30)
+    scores = np.linspace(0, 1, 30)
+    result = compute_lift_at_k(y, scores, 10, zero_division=0.0)
+    assert result == 0.0
+
+
+def test_lift_at_k_sanitizes_nan_scores():
+    y = np.array([0, 1, 0, 1])
+    scores = np.array([0.1, np.nan, 0.2, 0.3])
+    result = compute_lift_at_k(y, scores, 50)
+    assert not np.isnan(result)
+
+
+def test_lift_at_k_invalid_k_percent():
+    with pytest.raises(ValueError):
+        compute_lift_at_k(np.array([0, 1]), np.array([0.1, 0.2]), 120)
+
+
+def test_weighted_lift_handles_nan_and_zero_base():
+    y = np.zeros(4)
+    scores = np.array([0.1, 0.2, np.nan, 0.4])
+    weights = np.array([1.0, np.nan, 2.0, 1.0])
+    result = compute_weighted_lift_at_k(y, scores, weights, 50)
+    assert np.isnan(result)
 
 


### PR DESCRIPTION
## Summary
- validate k_percent bounds and expose zero_division in lift metrics
- sanitize NaN scores/weights and return configurable default when base rate is zero
- extend metrics tests for zero-base, NaN, and invalid k scenarios

## Testing
- `ruff check gosales/models/metrics.py gosales/tests/test_phase3_metrics.py`
- `PYTHONPATH=$PWD pytest gosales/tests/test_phase3_metrics.py -q`
- `PYTHONPATH=$PWD pytest -q` *(fails: test_feature_cli_checksum, test_determinism_in_memory, test_drift_psi_smoke, test_calibration_sanity, test_per_feature_psi_highlight, test_scenarios_math_and_segment_csv, test_per_rep_and_hybrid_scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_68a00a0b570c833381f6e6d76f5eba48