### PR TITLE
Handle constant series in percentile normalization

### DIFF
--- a/gosales/pipeline/rank_whitespace.py
+++ b/gosales/pipeline/rank_whitespace.py
@@ -19,6 +19,8 @@ def _percentile_normalize(s: pd.Series) -> pd.Series:
     """Map values in s to [0,1] by rank-percentile with stable handling of ties."""
     if s is None or len(s) == 0:
         return pd.Series([], dtype=float)
+    if s.nunique(dropna=True) <= 1:
+        return pd.Series(np.zeros(len(s)), index=s.index, dtype=float)
     # Use average rank method to be stable across runs
     ranks = s.rank(method="average", pct=True)
     return ranks.astype(float)

--- a/gosales/tests/test_phase4_rank_normalization.py
+++ b/gosales/tests/test_phase4_rank_normalization.py
@@ -18,3 +18,9 @@ def test_percentile_normalize_uniform_like():
     assert p2.std() > 0.15
 
 
+def test_percentile_normalize_constant_values():
+    s = pd.Series([5.0] * 10)
+    p = _percentile_normalize(s)
+    assert (p == 0).all()
+
+


### PR DESCRIPTION
## Summary
- Return zeros when `_percentile_normalize` receives a constant series
- Test that constant inputs produce all-zero normalized output

## Testing
- `PYTHONPATH=. pytest gosales/tests/test_phase4_rank_normalization.py::test_percentile_normalize_constant_values -q`
- `PYTHONPATH=. pytest` *(fails: AssertionError in test_feature_cli_checksum; determinism test)*

------
https://chatgpt.com/codex/tasks/task_e_68a00a4006d08333a6ece69fe22186f2