### PR TITLE
Sanitize inference features before scoring

### DIFF
--- a/gosales/tests/test_score_p_icp_sanitizes.py
+++ b/gosales/tests/test_score_p_icp_sanitizes.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pandas as pd
+
+from gosales.pipeline.score_customers import _score_p_icp
+
+
+class DummyModel:
+    def predict_proba(self, X: pd.DataFrame):
+        # Ensure all columns are float and finite
+        assert all(pd.api.types.is_float_dtype(dt) for dt in X.dtypes)
+        assert np.isfinite(X.to_numpy()).all()
+        # Return fixed probabilities
+        return np.tile([0.2, 0.8], (len(X), 1))
+
+
+def test_score_p_icp_handles_nan_inf_and_non_numeric():
+    df = pd.DataFrame(
+        {
+            "a": [1.0, np.nan, np.inf, -np.inf],
+            "b": ["1", "two", None, 3],
+        }
+    )
+    probs = _score_p_icp(DummyModel(), df)
+    assert probs.shape == (4,)
+    assert np.isfinite(probs).all()


### PR DESCRIPTION
## Summary
- Add `_sanitize_features` helper and `_score_p_icp` to clean non-numeric, NaN, and inf values
- Use `_score_p_icp` in `score_customers_for_division` for safe model predictions
- Test scoring with NaN/inf inputs to ensure sanitization works

## Testing
- `PYTHONPATH=. pytest gosales/tests/test_score_p_icp_sanitizes.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gosales')*


------
https://chatgpt.com/codex/tasks/task_e_68a00c69c39c8333857fd971ba56ecc7