### PR TITLE
Validate and normalize whitespace weights

### DIFF
--- a/gosales/README.md
+++ b/gosales/README.md
@@ -30,7 +30,7 @@ A division-focused Ideal Customer Profile (ICP) & Whitespace engine. The pipelin
 - **Phase 4 — Whitespace Ranking / Next‑Best‑Action**
   - Signals: calibrated probability (`p_icp` + per‑division percentile), market‑basket affinity (`mb_lift_max`, `mb_lift_mean`), ALS similarity (explicit or embedding‑centroid), expected value proxy (segment‑blended and capped)
   - Normalization: per‑division percentile (default) or pooled across divisions
-  - Blending: configurable weights (default `0.60,0.20,0.10,0.10`) → single actionable score; optional challenger meta‑learner (`score_challenger`)
+  - Blending: configurable weights (default `0.60,0.20,0.10,0.10`) → single actionable score; weights must be four non‑negative numbers and are normalized to sum to 1; optional challenger meta‑learner (`score_challenger`)
   - Capacity: top‑percent, per‑rep, or hybrid diversification (round‑robin interleave)
   - Gating: ownership, region, recent contact, open deal; cooldown de‑emphasis; structured JSONL logs
   - Artifacts: `whitespace_<cutoff>.csv` (includes `score` and `score_challenger`), `whitespace_explanations_<cutoff>.csv`, `thresholds_whitespace_<cutoff>.csv`, `whitespace_metrics_<cutoff>.json`, `whitespace_log_<cutoff>.jsonl`, `mb_rules_<division>_<cutoff>.csv`, optional `whitespace_legacy_<cutoff>.csv` (shadow), `whitespace_overlap_<cutoff>.json`

--- a/gosales/config.yaml
+++ b/gosales/config.yaml
@@ -48,7 +48,7 @@ modeling:
   capacity_percent: 10
 
 whitespace:
-  weights: [0.60, 0.20, 0.10, 0.10]   # [p_icp_pct, lift_norm, als_norm, EV_norm]
+  weights: [0.60, 0.20, 0.10, 0.10]   # [p_icp_pct, lift_norm, als_norm, EV_norm]; non-negative, auto-normalized
   normalize: percentile               # percentile | pooled
   eligibility:
     exclude_if_owned_ever: true


### PR DESCRIPTION
## Summary
- validate whitespace weight list: ensure finite, non-negative, and normalize to sum to 1
- document weight format in config and README
- test invalid weight inputs and normalization behavior

## Testing
- `ruff check gosales/utils/config.py gosales/tests/test_phase6_config_and_registry.py`
- `PYTHONPATH=$PWD pytest gosales/tests/test_phase6_config_and_registry.py gosales/tests/test_phase4_weight_scaling_and_als.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a00c98f4cc83339b97c5d26d1b1429