### PR TITLE
Use partial partition for top-percent thresholds

### DIFF
--- a/gosales/pipeline/score_customers.py
+++ b/gosales/pipeline/score_customers.py
@@ -431,7 +431,8 @@ def generate_scoring_outputs(engine, *, run_manifest: dict | None = None):
                     if scores_num.size > 0:
                         for i, k in enumerate([5, 10, 20]):
                             kk = max(1, int(scores_num.size * (k / 100.0)))
-                            thr = float(np.sort(scores_num)[-kk])
+                            pos = scores_num.size - kk
+                            thr = float(np.partition(scores_num, pos)[pos])
                             count = int((pd.to_numeric(ranked['score'], errors='coerce') >= thr).sum())
                             thresholds[i]["threshold"] = thr
                             thresholds[i]["count"] = count
@@ -468,14 +469,16 @@ def generate_scoring_outputs(engine, *, run_manifest: dict | None = None):
                     if mode == 'top_percent':
                         if len(ranked) > 0:
                             ksel = max(1, int(len(ranked) * (cfg.modeling.capacity_percent / 100.0)))
-                            thr_sel = float(np.sort(ranked['score'].values)[-ksel])
+                            pos = len(ranked) - ksel
+                            thr_sel = float(np.partition(ranked['score'].values, pos)[pos])
                             selected = ranked[ranked['score'] >= thr_sel].copy()
                         else:
                             selected = ranked
                     elif mode in ('per_rep','hybrid'):
                         # Fallback to top_percent until rep attribution/interleave available
                         ksel = max(1, int(len(ranked) * (cfg.modeling.capacity_percent / 100.0)))
-                        thr_sel = float(np.sort(ranked['score'].values)[-ksel]) if len(ranked) else float('nan')
+                        pos = len(ranked) - ksel
+                        thr_sel = float(np.partition(ranked['score'].values, pos)[pos]) if len(ranked) else float('nan')
                         selected = ranked[ranked['score'] >= thr_sel].copy()
 
                     sel_name = f"whitespace_selected_{cutoff_tag}.csv" if cutoff_tag else "whitespace_selected.csv"


### PR DESCRIPTION
## Summary
- Use `np.partition` to compute top-percentile thresholds without sorting the entire array
- Apply the same optimization to fallback paths of capacity selection

## Testing
- `PYTHONPATH=$PWD pytest gosales/tests/test_phase4_bias_diversity_warning.py -q`
- `PYTHONPATH=$PWD pytest gosales/tests/test_phase4_capture_at_k.py -q`
- `PYTHONPATH=$PWD pytest gosales/tests/test_phase4_rank_normalization.py -q`
- `PYTHONPATH=$PWD pytest gosales/tests/test_phase4_weight_scaling_and_als.py -q`
- `PYTHONPATH=$PWD pytest gosales/tests/test_ui_smoke.py -q`
- `python - <<'PY'
import numpy as np, time
n = 2_000_000
arr = np.random.random(n)
k = int(n * 0.05)
start = time.perf_counter(); thr_sort = np.sort(arr)[-k]; t_sort = time.perf_counter()-start
start = time.perf_counter(); thr_part = np.partition(arr, n - k)[n - k]; t_part = time.perf_counter()-start
print('threshold match?', np.allclose(thr_sort, thr_part))
print('np.sort time', t_sort)
print('np.partition time', t_part)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a00e18ebf88333951c09d33010696e