### PR TITLE
Preserve ALS mappings and provide readable outputs

### DIFF
--- a/gosales/tests/test_whitespace_als_smoke.py
+++ b/gosales/tests/test_whitespace_als_smoke.py
@@ -1,0 +1,16 @@
+import polars as pl
+import sqlalchemy as sa
+from gosales.whitespace.als import build_als
+
+
+def test_build_als_outputs_readable_ids(tmp_path):
+    engine = sa.create_engine('sqlite://')
+    data = pl.DataFrame({'customer_id': [1, 1, 2], 'product_name': ['A', 'B', 'A']})
+    data.write_database('fact_orders', engine, if_table_exists='replace')
+    output_path = tmp_path / 'als.csv'
+    build_als(engine, output_path)
+    result = pl.read_csv(output_path)
+    assert {'customer_id', 'product_name'} <= set(result.columns)
+    assert set(result['product_name'].to_list()) <= {'A', 'B'}
+    assert set(result['customer_id'].to_list()) <= {1, 2}
+


### PR DESCRIPTION
## Summary
- Encode ALS user/item indices with mapping dictionaries and emit readable CSV
- Add smoke test ensuring ALS recommendations file contains customer and product names

## Testing
- `PYTHONPATH=. pytest gosales/tests/test_whitespace_als_smoke.py::test_build_als_outputs_readable_ids -q`

------
https://chatgpt.com/codex/tasks/task_e_68a08a7b80b083338814211b2fc57ab9