### PR TITLE
Handle missing whitespace divisions

### DIFF
--- a/gosales/features/als_embed.py
+++ b/gosales/features/als_embed.py
@@ -20,7 +20,9 @@ def _build_user_item(df: pd.DataFrame, user_col: str, item_col: str, weight_col:
 def _als_with_implicit(mat: coo_matrix, factors: int, reg: float, alpha: float) -> pd.DataFrame | None:
     try:
         import implicit
-        model = implicit.als.AlternatingLeastSquares(factors=factors, regularization=reg)
+        model = implicit.als.AlternatingLeastSquares(
+            factors=factors, regularization=reg, random_state=42
+        )
         model.fit((mat * alpha).astype('double'))
         return pd.DataFrame(model.user_factors)
     except Exception:

--- a/gosales/pipeline/score_customers.py
+++ b/gosales/pipeline/score_customers.py
@@ -278,7 +278,15 @@ def generate_whitespace_opportunities(engine):
             ])
         )
         
-        all_divisions = transactions.select("product_division").unique()["product_division"].to_list()
+        all_divisions = (
+            transactions
+            .filter(
+                pl.col("product_division").is_not_null()
+                & (pl.col("product_division").str.strip_chars() != "")
+            )
+            .select("product_division")
+            .unique()["product_division"].to_list()
+        )
         
         opportunities = []
         for row in customer_summary.iter_rows(named=True):

--- a/gosales/tests/test_features.py
+++ b/gosales/tests/test_features.py
@@ -11,9 +11,9 @@ from gosales.utils.paths import OUTPUTS_DIR
 
 def _seed(engine):
     fact = pd.DataFrame([
-        {"customer_id": 1, "order_date": "2024-01-01", "product_division": "Solidworks", "product_sku": "SWX_Core", "gross_profit": 100},
-        {"customer_id": 1, "order_date": "2024-02-01", "product_division": "Services", "product_sku": "Training", "gross_profit": 5},
-        {"customer_id": 2, "order_date": "2023-12-15", "product_division": "Simulation", "product_sku": "Simulation", "gross_profit": 50},
+        {"customer_id": 1, "order_date": "2024-01-01", "product_division": "Solidworks", "product_sku": "SWX_Core", "gross_profit": 100, "quantity": 1},
+        {"customer_id": 1, "order_date": "2024-02-01", "product_division": "Services", "product_sku": "Training", "gross_profit": 5, "quantity": 1},
+        {"customer_id": 2, "order_date": "2023-12-15", "product_division": "Simulation", "product_sku": "Simulation", "gross_profit": 50, "quantity": 1},
     ])
     fact.to_sql("fact_transactions", engine, if_exists="replace", index=False)
     pd.DataFrame({"customer_id": [1, 2]}).to_sql("dim_customer", engine, if_exists="replace", index=False)
@@ -34,6 +34,10 @@ def test_feature_cli_checksum(tmp_path, monkeypatch):
     # Use temp output dir by monkeypatching OUTPUTS_DIR if needed
     eng = create_engine(f"sqlite:///{tmp_path}/test_features_cli.db")
     _seed(eng)
+    # Seed the default database used by the CLI
+    from gosales.utils.db import get_db_connection
+
+    _seed(get_db_connection())
     # Build via engine first
     fm = create_feature_matrix(eng, "Solidworks", cutoff_date="2024-01-31", prediction_window_months=1)
     assert not fm.is_empty()

--- a/gosales/tests/test_whitespace_missing_divisions.py
+++ b/gosales/tests/test_whitespace_missing_divisions.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import polars as pl
+from sqlalchemy import create_engine
+
+from gosales.pipeline.score_customers import generate_whitespace_opportunities
+
+
+def test_generate_whitespace_opportunities_skips_missing_divisions():
+    engine = create_engine("sqlite:///:memory:")
+
+    transactions_df = pd.DataFrame(
+        {
+            "customer_id": [1, 1, 2, 3],
+            "product_division": ["A", None, "", "B"],
+            "gross_profit": [100, 200, 150, 250],
+        }
+    )
+    customers_df = pd.DataFrame({"customer_id": [1, 2, 3]})
+
+    transactions_df.to_sql("fact_transactions", engine, index=False)
+    customers_df.to_sql("dim_customer", engine, index=False)
+
+    ws_df = generate_whitespace_opportunities(engine)
+    missing = ws_df.filter(
+        pl.col("whitespace_division").is_null()
+        | (pl.col("whitespace_division") == "")
+    )
+    assert missing.height == 0
+


### PR DESCRIPTION
## Summary
- skip null or empty `product_division` values when deriving `all_divisions`
- add regression test ensuring whitespace rows always contain a division name
- seed ALS random state and test database for deterministic feature builds

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a092a374b08333961006070dd9084d