### PR TITLE
Fix validation dry run context usage and add regression test

### DIFF
--- a/gosales/tests/test_phase5_dry_run.py
+++ b/gosales/tests/test_phase5_dry_run.py
@@ -1,0 +1,31 @@
+import json
+
+from click.testing import CliRunner
+import gosales.validation.forward as forward
+import gosales.utils.paths as paths
+import gosales.ops.run as run_module
+
+
+def test_dry_run_creates_single_run(tmp_path, monkeypatch):
+    fake_outputs = tmp_path / "outputs"
+    monkeypatch.setattr(paths, "OUTPUTS_DIR", fake_outputs)
+    monkeypatch.setattr(forward, "OUTPUTS_DIR", fake_outputs)
+    monkeypatch.setattr(run_module, "OUTPUTS_DIR", fake_outputs)
+
+    runner = CliRunner()
+    result = runner.invoke(forward.main, [
+        "--division", "Solidworks",
+        "--cutoff", "2099-12-31",
+        "--dry-run",
+    ])
+    assert result.exit_code == 0
+
+    runs_dir = fake_outputs / "runs"
+    run_dirs = [p for p in runs_dir.iterdir() if p.is_dir()]
+    assert len(run_dirs) == 1
+    assert (run_dirs[0] / "logs.jsonl").exists()
+
+    registry_path = runs_dir / "runs.jsonl"
+    entries = [json.loads(line) for line in registry_path.read_text(encoding="utf-8").splitlines()]
+    run_ids = {e["run_id"] for e in entries}
+    assert len(run_ids) == 1

--- a/gosales/validation/forward.py
+++ b/gosales/validation/forward.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Tuple, Callable
 
 import click
 import numpy as np
@@ -22,7 +21,7 @@ logger = get_logger(__name__)
 
 
 def _load_model_and_features(division: str):
-    import joblib, json
+    import joblib
     model_dir = MODELS_DIR / f"{division.lower()}_model"
     model_path = model_dir / "model.pkl"
     feat_path = model_dir / "feature_list.json"
@@ -132,10 +131,9 @@ def main(division: str, cutoff: str, window_months: int, capacity_grid: str, acc
             artifacts['planned_validation_frame.parquet'] = str(out_dir / 'validation_frame.parquet')
             for name in ['gains.csv','calibration.csv','topk_scenarios.csv','topk_scenarios_sorted.csv','segment_performance.csv','metrics.json','drift.json','alerts.json']:
                 artifacts[f'planned_{name}'] = str(out_dir / name)
-            ctx = run_context("phase5_validation").__enter__()
             ctx['write_manifest'](artifacts)
             ctx['append_registry']({'phase': 'phase5_validation', 'division': division, 'cutoff': cutoff, 'artifact_count': len(artifacts), 'status': 'dry-run'})
-            run_context("phase5_validation").__exit__(None, None, None)
+            ctx_cm.__exit__(None, None, None)
         except Exception:
             pass
         return


### PR DESCRIPTION
## Summary
- Ensure validation dry run reuses its original run context and properly exits
- Add regression test confirming a dry run produces a single run and log entry

## Testing
- `ruff check gosales/validation/forward.py gosales/tests/test_phase5_dry_run.py`
- `PYTHONPATH=. pytest gosales/tests/test_phase5_dry_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09d10064c83339a17797ac1b66120