### PR TITLE
Handle constant prediction scores before quantile binning

### DIFF
--- a/gosales/tests/test_deciles_constant.py
+++ b/gosales/tests/test_deciles_constant.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pandas as pd
+
+from gosales.validation.deciles import gains_and_capture
+
+
+def test_gains_and_capture_decile_counts(tmp_path):
+    # Constant scores should yield a single decile
+    df = pd.DataFrame({
+        'division_name': ['A'] * 5,
+        'icp_score': [0.5] * 5,
+        'bought_in_division': [0, 1, 0, 1, 0],
+    })
+    path = tmp_path / 'const.csv'
+    df.to_csv(path, index=False)
+    gains, _ = gains_and_capture(path)
+    assert gains['decile'].nunique() == 1
+    assert len(gains) == 1
+
+    # Diverse scores should yield 10 deciles
+    df2 = pd.DataFrame({
+        'division_name': ['A'] * 20,
+        'icp_score': np.linspace(0, 1, 20),
+        'bought_in_division': [0, 1] * 10,
+    })
+    path2 = tmp_path / 'var.csv'
+    df2.to_csv(path2, index=False)
+    gains2, _ = gains_and_capture(path2)
+    assert gains2['decile'].nunique() == 10
+    assert len(gains2) == 10

--- a/gosales/tests/test_phase3_metrics.py
+++ b/gosales/tests/test_phase3_metrics.py
@@ -29,6 +29,15 @@ def test_calibration_bins_and_mae():
     assert mae < 0.02  # near-perfect calibration should have very small MAE
 
 
+def test_calibration_bins_constant_scores():
+    y = np.array([0, 1, 0, 1, 0])
+    p = np.array([0.5] * 5)
+    bins = calibration_bins(y, p, n_bins=10)
+    # With constant scores we should fall back to a single bin
+    assert len(bins) == 1
+    assert bins['count'].iloc[0] == 5
+
+
 def test_lift_at_k_monotonic():
     # Higher scores correspond to higher y_prob → lift should be > 1
     y = np.array([0]*90 + [1]*10)

--- a/gosales/validation/forward.py
+++ b/gosales/validation/forward.py
@@ -92,12 +92,20 @@ def _gains_deciles(y: np.ndarray, p: np.ndarray) -> pd.DataFrame:
 
 def _calibration_bins(y: np.ndarray, p: np.ndarray, n_bins: int = 10) -> pd.DataFrame:
     df = pd.DataFrame({'y': y, 'p': p})
-    try:
+    uniq = df['p'].nunique(dropna=False)
+    if uniq >= n_bins:
         bins = pd.qcut(df['p'], q=n_bins, duplicates='drop')
-    except Exception:
-        bins = pd.cut(df['p'], bins=n_bins, include_lowest=True, duplicates='drop')
+    else:
+        bins = pd.cut(
+            df['p'],
+            bins=max(1, min(n_bins, uniq)),
+            include_lowest=True,
+            duplicates='drop',
+        )
     return df.assign(bin=bins).groupby('bin', observed=False).agg(
-        mean_predicted=('p','mean'), fraction_positives=('y','mean'), count=('y','size')
+        mean_predicted=('p', 'mean'),
+        fraction_positives=('y', 'mean'),
+        count=('y', 'size'),
     ).reset_index(drop=True)
 
 


### PR DESCRIPTION
## Summary
- Check unique prediction scores before using `pd.qcut`, falling back to `pd.cut` or reduced bins when needed
- Ensure validation decile calculations handle constant scores gracefully
- Add tests for constant-score scenarios and decile counts

## Testing
- `PYTHONPATH=. pytest gosales/tests/test_phase3_metrics.py gosales/tests/test_deciles_constant.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a2a0f4488333b71b27d3c71e4606