### PR TITLE
Handle missing features in challenger model

### DIFF
--- a/gosales/pipeline/rank_whitespace.py
+++ b/gosales/pipeline/rank_whitespace.py
@@ -15,6 +15,10 @@ from gosales.utils.paths import OUTPUTS_DIR
 logger = get_logger(__name__)
 
 
+# Features used by challenger meta-learner. Tests may monkeypatch this list.
+CHALLENGER_FEAT_COLS = ["p_icp_pct", "lift_norm", "als_norm", "EV_norm"]
+
+
 def _percentile_normalize(s: pd.Series) -> pd.Series:
     """Map values in s to [0,1] by rank-percentile with stable handling of ties."""
     if s is None or len(s) == 0:
@@ -192,7 +196,12 @@ def rank_whitespace(inputs: RankInputs, *, weights: Iterable[float] = (0.60, 0.2
     if challenger_on and challenger_model == 'lr':
         try:
             from sklearn.linear_model import LogisticRegression
-            Xmeta = df[['p_icp_pct', 'lift_norm', 'als_norm', 'EV_norm']].to_numpy(dtype=float)
+
+            feat_cols = list(CHALLENGER_FEAT_COLS)
+            missing = [c for c in feat_cols if c not in df]
+            for c in missing:
+                df[c] = 0.0
+            Xmeta = df[feat_cols].to_numpy(dtype=float)
             # Pseudo-label: use p_icp as soft target for ranking consistency; this is a heuristic challenger
             ysoft = df['p_icp'].to_numpy(dtype=float)
             # Fit Platt-like logistic on the normalized components to approximate p_icp ordering

--- a/gosales/tests/test_phase4_challenger_feature_list.py
+++ b/gosales/tests/test_phase4_challenger_feature_list.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pandas as pd
+import types
+
+import gosales.pipeline.rank_whitespace as rw
+
+
+def test_rank_whitespace_handles_extra_feature(monkeypatch):
+    n = 10
+    df = pd.DataFrame(
+        {
+            "division_name": ["A"] * n,
+            "customer_id": np.arange(n),
+            "icp_score": np.linspace(0.1, 0.9, n),
+            "mb_lift_max": np.linspace(0.1, 0.9, n),
+            "als_f0": np.linspace(0.1, 0.9, n),
+            "rfm__all__gp_sum__12m": np.linspace(10.0, 100.0, n),
+        }
+    )
+
+    cfg = types.SimpleNamespace(
+        whitespace=types.SimpleNamespace(
+            challenger_enabled=True, challenger_model="lr", ev_cap_percentile=0.95
+        )
+    )
+    import gosales.utils.config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: cfg)
+    monkeypatch.setattr(rw, "CHALLENGER_FEAT_COLS", rw.CHALLENGER_FEAT_COLS + ["extra_col"])
+
+    result = rw.rank_whitespace(rw.RankInputs(scores=df))
+    assert "score" in result.columns
+    assert "score_challenger" in result.columns
+    assert len(result) == n


### PR DESCRIPTION
## Summary
- avoid KeyErrors when challenger feature list contains unseen columns
- add unit test ensuring extra challenger features are zero-filled

## Testing
- `ruff check gosales/pipeline/rank_whitespace.py gosales/tests/test_phase4_challenger_feature_list.py`
- `PYTHONPATH=$PWD pytest gosales/tests/test_phase4_challenger_feature_list.py -q`
- `PYTHONPATH=$PWD pytest -q` *(fails: no such table: fact_transactions)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e0e78bc08333b890755d268e25a8