### PR TITLE
fix: preserve division casing when discovering models

### DIFF
--- a/gosales/pipeline/score_customers.py
+++ b/gosales/pipeline/score_customers.py
@@ -35,16 +35,17 @@ def discover_available_models(models_dir: Path | None = None) -> dict[str, Path]
     root = models_dir or MODELS_DIR
     available: dict[str, Path] = {}
     for p in root.glob("*_model"):
-        meta_div = None
+        div = p.name.replace("_model", "")
+        meta_path = p / "metadata.json"
         try:
-            meta_path = p / "metadata.json"
             if meta_path.exists():
                 with open(meta_path, "r", encoding="utf-8") as f:
                     meta = json.load(f)
                     meta_div = normalize_division(meta.get("division"))
+                    if meta_div:
+                        div = meta_div
         except Exception:
-            meta_div = None
-        div = meta_div if meta_div else p.name.replace("_model", "")
+            pass
         available[div] = p
     return available
 

--- a/gosales/tests/test_discover_available_models.py
+++ b/gosales/tests/test_discover_available_models.py
@@ -1,0 +1,42 @@
+import types
+import sys
+from pathlib import Path
+
+
+def setup_score_customers_import():
+    mlflow_stub = types.SimpleNamespace(sklearn=types.SimpleNamespace())
+    features_engine_stub = types.SimpleNamespace(create_feature_matrix=lambda *a, **k: None)
+    rank_whitespace_stub = types.SimpleNamespace(rank_whitespace=None, save_ranked_whitespace=None, RankInputs=None)
+    deciles_stub = types.SimpleNamespace(emit_validation_artifacts=lambda *a, **k: None)
+    schema_stub = types.SimpleNamespace(
+        validate_icp_scores_schema=lambda *a, **k: None,
+        validate_whitespace_schema=lambda *a, **k: None,
+        write_schema_report=lambda *a, **k: None,
+    )
+    drift_stub = types.SimpleNamespace(check_drift_and_emit_alerts=lambda *a, **k: None)
+
+    modules = {
+        'mlflow': mlflow_stub,
+        'mlflow.sklearn': mlflow_stub.sklearn,
+        'gosales.features.engine': features_engine_stub,
+        'gosales.pipeline.rank_whitespace': rank_whitespace_stub,
+        'gosales.validation.deciles': deciles_stub,
+        'gosales.validation.schema': schema_stub,
+        'gosales.monitoring.drift': drift_stub,
+    }
+    for name, mod in modules.items():
+        sys.modules.setdefault(name, mod)
+
+
+
+def test_discover_available_models_preserves_casing(tmp_path):
+    setup_score_customers_import()
+    from gosales.pipeline.score_customers import discover_available_models
+
+    models_root = tmp_path
+    model_dir = models_root / "Multi Word_model"
+    model_dir.mkdir()
+
+    available = discover_available_models(models_root)
+    assert "Multi Word" in available
+    assert available["Multi Word"] == model_dir


### PR DESCRIPTION
## Summary
- avoid capitalizing division names when discovering models
- add regression test ensuring multi-word division names retain their original casing

## Testing
- `pytest gosales/tests/test_discover_available_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e1013aac83339c816f09680131a9