### PR TITLE
fix: normalize scoring model pruning keys

### DIFF
--- a/gosales/tests/test_discover_available_models.py
+++ b/gosales/tests/test_discover_available_models.py
@@ -40,3 +40,22 @@ def test_discover_available_models_preserves_casing(tmp_path):
     available = discover_available_models(models_root)
     assert "Multi Word" in available
     assert available["Multi Word"] == model_dir
+
+
+def test_model_without_metadata_survives_pruning(tmp_path):
+    setup_score_customers_import()
+    from gosales.pipeline.score_customers import (
+        discover_available_models,
+        _filter_models_by_targets,
+    )
+
+    models_root = tmp_path
+    model_dir = models_root / "SW_Inspection_model"
+    model_dir.mkdir()
+
+    available = discover_available_models(models_root)
+    assert "SW_Inspection" in available
+
+    filtered = _filter_models_by_targets(available, {"SW Inspection"})
+    assert "SW_Inspection" in filtered
+    assert filtered["SW_Inspection"] == model_dir


### PR DESCRIPTION
## Summary
- harmonize discovered model keys with supported targets before pruning in the scoring pipeline
- add helper utilities and tests to ensure metadata-free model folders survive filtering

## Testing
- pytest gosales/tests/test_discover_available_models.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d76dcccca88333bbd387a6b73208fd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize model/target keys during pruning to ensure models (including metadata-free folders) aren’t incorrectly filtered out, and add tests.
> 
> - **Scoring pipeline** (`gosales/pipeline/score_customers.py`):
>   - Add `_normalize_model_key` and `_filter_models_by_targets` to harmonize model keys (spacing/underscore/case) with supported targets.
>   - Use `_filter_models_by_targets` to prune `available_models` instead of direct key membership.
> - **Tests** (`gosales/tests/test_discover_available_models.py`):
>   - Add test ensuring models without `metadata.json` survive pruning when target matches normalized key (`SW_Inspection` ↔ `SW Inspection`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3283bb269469ee0adb47916cf3deb5d67164b28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->