### PR TITLE
Fix create_feature_matrix when no cutoff provided

### DIFF
--- a/gosales/features/engine.py
+++ b/gosales/features/engine.py
@@ -70,6 +70,7 @@ def create_feature_matrix(engine, division_name: str, cutoff_date: str = None, p
             )
             feature_data = _read_sql(feature_sql, {"cutoff": cutoff_date})
             feature_data["order_date"] = pd.to_datetime(feature_data["order_date"])
+            transactions_pd = feature_data.copy()
 
             from dateutil.relativedelta import relativedelta
 
@@ -117,6 +118,7 @@ def create_feature_matrix(engine, division_name: str, cutoff_date: str = None, p
             )
             feature_data = _read_sql(feature_sql)
             feature_data["order_date"] = pd.to_datetime(feature_data["order_date"])
+            transactions_pd = feature_data.copy()
             prediction_data = feature_data.copy()
 
         transactions = pl.from_pandas(feature_data)

--- a/gosales/tests/test_features.py
+++ b/gosales/tests/test_features.py
@@ -33,6 +33,16 @@ def test_feature_window_and_target(tmp_path):
     assert int(pdf.loc[pdf["customer_id"] == 2, "bought_in_division"].iloc[0]) == 0
 
 
+def test_feature_matrix_without_cutoff(tmp_path):
+    eng = create_engine(f"sqlite:///{tmp_path}/test_features_no_cutoff.db")
+    _seed(eng)
+
+    feature_frame = create_feature_matrix(eng, "Solidworks", cutoff_date=None, prediction_window_months=1)
+
+    assert not feature_frame.is_empty()
+    assert feature_frame.height > 0
+
+
 def test_feature_cli_checksum(tmp_path, monkeypatch):
     eng = create_engine(f"sqlite:///{tmp_path}/test_features_cli.db")
     _seed(eng)


### PR DESCRIPTION
## Summary
- ensure create_feature_matrix reuses the loaded feature data when no cutoff date is provided to avoid undefined references
- add a regression test covering create_feature_matrix with cutoff_date=None

## Testing
- PYTHONPATH=. pytest gosales/tests/test_features.py::test_feature_matrix_without_cutoff -q

------
https://chatgpt.com/codex/tasks/task_e_68d76dd022f48333be7a1a8aa2af082f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the no-cutoff execution by preserving loaded transactions for downstream features and adds a regression test.
> 
> - **Features**:
>   - In `gosales/features/engine.py`, preserve loaded transactions as `transactions_pd` when `cutoff_date` is None (and when provided) to support downstream window/recency computations.
> - **Tests**:
>   - Add `test_feature_matrix_without_cutoff` validating non-empty output when `cutoff_date=None`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15c7ebf8a743f874434b0cfd655f44c9c8f86ea6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->