### PR TITLE
Fix SHAP reason normalization and add tests

### DIFF
--- a/gosales/models/shap_utils.py
+++ b/gosales/models/shap_utils.py
@@ -17,34 +17,62 @@ def compute_shap_reasons(model, X: pd.DataFrame, feature_cols: Iterable[str], to
     Falls back gracefully if `shap` is unavailable.
     Returns a DataFrame with columns [reason_1, reason_2, reason_3].
     """
+    def _empty_reasons() -> pd.DataFrame:
+        return pd.DataFrame({f"reason_{i+1}": [None] * len(X) for i in range(top_k)})
+
     try:
         import shap  # type: ignore
     except Exception as exc:  # pragma: no cover
         logger.warning("SHAP not available: %s; skipping reason codes", exc)
-        return pd.DataFrame({f"reason_{i+1}": [None] * len(X) for i in range(top_k)})
+        return _empty_reasons()
 
     # Unwrap calibrator wrapper if present
+    model_for_shap = model
     try:
         from sklearn.calibration import CalibratedClassifierCV  # type: ignore
-        if isinstance(model, CalibratedClassifierCV) and hasattr(model, 'base_estimator'):
-            base = getattr(model, 'base_estimator', None) or getattr(model, 'estimator', None)
+
+        if isinstance(model, CalibratedClassifierCV) and hasattr(model, "base_estimator"):
+            base = getattr(model, "base_estimator", None) or getattr(model, "estimator", None)
             if base is not None:
                 model_for_shap = base
-            else:
-                model_for_shap = model
-        else:
-            model_for_shap = model
-    except Exception:
+    except Exception:  # pragma: no cover - best effort unwrap
         model_for_shap = model
 
+    try:
         explainer = shap.TreeExplainer(model_for_shap)
         shap_values = explainer.shap_values(X[feature_cols])
-        # For binary classifier, shap_values may be list [neg_class, pos_class]; pick pos
-        if isinstance(shap_values, list) and len(shap_values) == 2:
-            shap_arr = shap_values[1]
+
+        # Normalize SHAP output to a (n_rows, n_features) numpy array
+        shap_candidate = shap_values
+        if isinstance(shap_candidate, list):
+            if len(shap_candidate) == 2:
+                shap_candidate = shap_candidate[1]
+            elif len(shap_candidate) > 0:
+                shap_candidate = shap_candidate[-1]
+            else:
+                return _empty_reasons()
+
+        if hasattr(shap_candidate, "values"):
+            shap_arr = np.asarray(shap_candidate.values)
         else:
-            shap_arr = shap_values
-        shap_arr = np.asarray(shap_arr)
+            shap_arr = np.asarray(shap_candidate)
+
+        if shap_arr.ndim == 3:
+            if shap_arr.shape[0] == len(X):
+                shap_arr = shap_arr[:, -1, :]
+            else:
+                shap_arr = shap_arr[-1]
+        elif shap_arr.ndim == 1:
+            shap_arr = shap_arr.reshape(-1, 1)
+
+        if shap_arr.shape[0] != len(X):
+            logger.warning(
+                "SHAP values shape mismatch (expected %s rows, got %s); skipping reason codes",
+                len(X),
+                shap_arr.shape[0],
+            )
+            return _empty_reasons()
+
         abs_vals = np.abs(shap_arr)
         top_idx = np.argsort(-abs_vals, axis=1)[:, :top_k]
         reasons = []
@@ -56,5 +84,5 @@ def compute_shap_reasons(model, X: pd.DataFrame, feature_cols: Iterable[str], to
         return reasons_df
     except Exception as exc:  # pragma: no cover
         logger.warning("SHAP failed: %s; skipping reason codes", exc)
-        return pd.DataFrame({f"reason_{i+1}": [None] * len(X) for i in range(top_k)})
+        return _empty_reasons()
 


### PR DESCRIPTION
## Summary
- normalize the SHAP output handling to always compute reasons after unwrapping calibrators
- centralize the fallback DataFrame creation when SHAP is unavailable or fails
- add a unit test that exercises compute_shap_reasons to ensure reason columns are populated when SHAP runs

## Testing
- PYTHONPATH=. pytest gosales/tests/test_score_customers.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d76de539048333bdb4b3be6dad445a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize SHAP output handling with robust unwrapping/shape logic, centralize fallback, and add a test ensuring reason columns are populated when SHAP runs.
> 
> - **Models (`gosales/models/shap_utils.py`)**:
>   - Add `_empty_reasons()` helper and reuse for all SHAP-unavailable/failure paths.
>   - Normalize SHAP outputs: unwrap `CalibratedClassifierCV`, handle list outputs (pick positive/last class), support `.values`, and reshape 1D/3D arrays; validate row count.
> - **Tests (`gosales/tests/test_score_customers.py`)**:
>   - Add `test_compute_shap_reasons_returns_non_empty_columns_when_shap` using `DecisionTreeClassifier` to verify reason columns are populated.
>   - Minor test imports/fixtures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80ed0a51bdabfbf60ea1be66297082e8dd30b135. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->