### PR TITLE
Fix ALS fallback when embedding coverage is sparse

### DIFF
--- a/gosales/pipeline/rank_whitespace.py
+++ b/gosales/pipeline/rank_whitespace.py
@@ -116,71 +116,79 @@ def _apply_eligibility_and_centroid(df: pd.DataFrame) -> Tuple[pd.DataFrame, np.
     return df, centroid
 
 
-def _compute_als_norm(df: pd.DataFrame, cfg=None, owner_centroid: np.ndarray | None = None) -> pd.Series:
-    """Compute ALS similarity normalized to [0,1].
+def _compute_als_norm(
+    df: pd.DataFrame,
+    cfg=None,
+    owner_centroid: np.ndarray | None = None,
+) -> Tuple[pd.Series, pd.Series]:
+    """Compute ALS similarity and raw signal strength.
 
-    - If owner_centroid is provided, use it; else derive from owned-pre-cutoff when available.
+    Returns a tuple ``(als_norm, als_signal_strength)`` where ``als_norm`` is the
+    percentile-normalized cosine similarity to the owner centroid, and
+    ``als_signal_strength`` captures the sum of absolute ALS embedding factors
+    per row. The raw strength is used to assess coverage and to identify rows
+    lacking embeddings (zero vectors or missing columns).
     """
-    als_cols = [c for c in df.columns if c.startswith("als_f")]
-    centroid: np.ndarray | None = None
-    if als_cols and "owned_division_pre_cutoff" in df.columns:
-        owners = df[df["owned_division_pre_cutoff"].astype(bool)]
-        if not owners.empty:
-            centroid = owners[als_cols].astype(float).mean(axis=0).to_numpy(dtype=float)
-            try:
-                ALS_CENTROID_PATH.parent.mkdir(parents=True, exist_ok=True)
-                np.save(ALS_CENTROID_PATH, centroid)
-            except Exception:
-                pass
-        elif ALS_CENTROID_PATH.exists():
-            try:
-                centroid = np.load(ALS_CENTROID_PATH)
-            except Exception:
-                centroid = None
-    elif ALS_CENTROID_PATH.exists():
-        try:
-            centroid = np.load(ALS_CENTROID_PATH)
-        except Exception:
-            centroid = None
 
-    if "owned_division_pre_cutoff" in df.columns:
-        df = df[~df["owned_division_pre_cutoff"].astype(bool)].copy()
+    if df.empty:
+        empty = pd.Series(np.zeros(len(df)), index=df.index, dtype=float)
+        return empty, empty.copy()
 
-    return df, centroid
-
-
-def _compute_als_norm(df: pd.DataFrame, cfg=None, owner_centroid: np.ndarray | None = None) -> pd.Series:
-    """Compute ALS similarity normalized to [0,1].
-
-    - If ``owner_centroid`` is provided, use it for similarity.
-    - Else, prefer centroid of rows where ``owned_division_pre_cutoff`` is True.
-      Fall back to global centroid if no owned rows.
-    """
     als_cols = [c for c in df.columns if c.startswith("als_f")]
     if not als_cols:
-        return pd.Series(np.zeros(len(df)), index=df.index, dtype=float)
-    mat = df[als_cols].astype(float)
+        empty = pd.Series(np.zeros(len(df)), index=df.index, dtype=float)
+        return empty, empty.copy()
+
+    mat = (
+        df[als_cols]
+        .apply(pd.to_numeric, errors="coerce")
+        .fillna(0.0)
+    )
     if mat.empty:
-        return pd.Series(np.zeros(len(df)), index=df.index, dtype=float)
+        empty = pd.Series(np.zeros(len(df)), index=df.index, dtype=float)
+        return empty, empty.copy()
+
+    # Measure raw embedding strength before any normalization.
+    raw_strength = mat.abs().sum(axis=1).astype(float)
 
     if owner_centroid is not None:
         centroid_vec = np.asarray(owner_centroid, dtype=float)
     else:
-        if 'owned_division_pre_cutoff' in df.columns:
-            try:
-                base = mat[df['owned_division_pre_cutoff'].astype(bool)]
-                centroid_vec = (base.mean(axis=0) if not base.empty else mat.mean(axis=0)).to_numpy(dtype=float)
-            except Exception:
-                centroid_vec = mat.mean(axis=0).to_numpy(dtype=float)
-        else:
+        try:
+            valid_mask = raw_strength > 0
+            if 'owned_division_pre_cutoff' in df.columns:
+                owned_mask = df['owned_division_pre_cutoff'].astype(bool) & valid_mask
+            else:
+                owned_mask = valid_mask
+            if owned_mask.any():
+                centroid_source = mat.loc[owned_mask]
+            elif valid_mask.any():
+                centroid_source = mat.loc[valid_mask]
+            else:
+                centroid_source = mat
+            centroid_vec = centroid_source.mean(axis=0).to_numpy(dtype=float)
+        except Exception:
             centroid_vec = mat.mean(axis=0).to_numpy(dtype=float)
 
-    m = mat.to_numpy(dtype=float)
-    # Normalize embeddings and centroid to unit length prior to similarity calc
-    m_norm = normalize(m, axis=1)
-    centroid_norm = normalize(centroid_vec.reshape(1, -1), axis=1)
-    sims = cosine_similarity(m_norm, centroid_norm).ravel()
-    return _percentile_normalize(pd.Series(sims, index=df.index))
+    if centroid_vec.shape[0] != mat.shape[1]:
+        centroid_vec = mat.mean(axis=0).to_numpy(dtype=float)
+
+    sims = np.zeros(len(df), dtype=float)
+    valid_rows = raw_strength > 0
+    if valid_rows.any():
+        m_valid = mat.loc[valid_rows].to_numpy(dtype=float)
+        try:
+            m_norm = normalize(m_valid, axis=1)
+            centroid_norm = normalize(centroid_vec.reshape(1, -1), axis=1)
+            sims_valid = cosine_similarity(m_norm, centroid_norm).ravel()
+        except Exception:
+            sims_valid = np.zeros(len(m_valid), dtype=float)
+        sims[valid_rows.to_numpy()] = sims_valid
+
+    als_norm = _percentile_normalize(pd.Series(sims, index=df.index))
+    als_norm.loc[~valid_rows] = 0.0
+
+    return als_norm.astype(float), raw_strength
 
 
 def _compute_expected_value(df: pd.DataFrame, cfg=None) -> pd.Series:
@@ -344,15 +352,23 @@ def _apply_eligibility(df: pd.DataFrame, cfg) -> tuple[pd.DataFrame, dict]:
     else:
         logger.info("Eligibility applied: %s kept, %s dropped", counts["kept_rows"], dropped)
     return df[mask].copy(), counts
-def _scale_weights_by_coverage(base_weights: Iterable[float], als_norm: pd.Series, lift_norm: pd.Series, threshold: float = 0.30) -> Tuple[List[float], Dict[str, float]]:
+def _scale_weights_by_coverage(
+    base_weights: Iterable[float],
+    als_norm: pd.Series,
+    lift_norm: pd.Series,
+    threshold: float = 0.30,
+    *,
+    als_signal: pd.Series | None = None,
+) -> Tuple[List[float], Dict[str, float]]:
     w = list(base_weights)
     if len(w) != 4:
         raise ValueError("Expected 4 weights: [p_icp_pct, lift, als, ev]")
     adjustments: Dict[str, float] = {}
     def coverage(s: pd.Series) -> float:
-        return float((pd.to_numeric(s, errors='coerce').fillna(0.0) > 0).mean())
+        arr = pd.to_numeric(s, errors="coerce").fillna(0.0)
+        return float((arr > 0).mean())
     cov_lift = coverage(lift_norm)
-    cov_als = coverage(als_norm)
+    cov_als = coverage(als_signal if als_signal is not None else als_norm)
     # Downweight components with low coverage; keep p_icp and ev fixed
     # Scale factor = min(1, cov/threshold) so when cov<th, shrink proportionally
     def factor(cov: float) -> float:
@@ -542,7 +558,9 @@ def rank_whitespace(inputs: RankInputs, *, weights: Iterable[float] = (0.60, 0.2
     df['p_icp_pct'] = df.groupby('division_name')['p_icp'].transform(_percentile_normalize)
     # Affinity lift and ALS similarity
     df['lift_norm'] = _compute_affinity_lift(df)
-    df['als_norm'] = _compute_als_norm(df, owner_centroid=als_centroid)
+    als_norm, als_signal_strength = _compute_als_norm(df, owner_centroid=als_centroid)
+    df['als_norm'] = als_norm
+    df['_als_signal_strength'] = als_signal_strength
     # ALS coverage enforcement and optional assets-ALS / item2vec backfill
     try:
         from gosales.utils.config import load_config
@@ -553,13 +571,17 @@ def rank_whitespace(inputs: RankInputs, *, weights: Iterable[float] = (0.60, 0.2
         als_thr = 0.30
         use_i2v = False
     try:
-        cov_als = (pd.to_numeric(df['als_norm'], errors='coerce').fillna(0.0) > 0).mean()
+        cov_als = (
+            pd.to_numeric(df['_als_signal_strength'], errors='coerce').fillna(0.0) > 0
+        ).mean()
     except Exception:
         cov_als = 0.0
     # Prefer assets-ALS fallback when available, else item2vec
     assets_als_present = any(c.startswith('als_assets_f') for c in df.columns)
     if cov_als < als_thr:
-        mask_zero_als = pd.to_numeric(df['als_norm'], errors='coerce').fillna(0.0) <= 0
+        mask_zero_als = (
+            pd.to_numeric(df['_als_signal_strength'], errors='coerce').fillna(0.0) <= 0
+        )
         if assets_als_present:
             try:
                 aals = _compute_assets_als_norm(df, owner_centroid=None)
@@ -571,7 +593,9 @@ def rank_whitespace(inputs: RankInputs, *, weights: Iterable[float] = (0.60, 0.2
         i2v_present = any(c.startswith('i2v_f') for c in df.columns)
         if (use_i2v or i2v_present):
             i2v_norm = _compute_item2vec_norm(df, owner_centroid=None)
-            mask_zero_als = pd.to_numeric(df['als_norm'], errors='coerce').fillna(0.0) <= 0
+            mask_zero_als = (
+                pd.to_numeric(df['_als_signal_strength'], errors='coerce').fillna(0.0) <= 0
+            )
             if mask_zero_als.any():
                 df.loc[mask_zero_als, 'als_norm'] = i2v_norm[mask_zero_als]
     # EV proxy with cap and normalization
@@ -623,9 +647,21 @@ def rank_whitespace(inputs: RankInputs, *, weights: Iterable[float] = (0.60, 0.2
             idx = g.index
             if len(g) < seg_min_rows:
                 # Fall back to global weights
-                w_adj, _ = _scale_weights_by_coverage(list(weights), df.loc[idx, 'als_norm'], df.loc[idx, 'lift_norm'], threshold=als_cov_thr)
+                w_adj, _ = _scale_weights_by_coverage(
+                    list(weights),
+                    df.loc[idx, 'als_norm'],
+                    df.loc[idx, 'lift_norm'],
+                    threshold=als_cov_thr,
+                    als_signal=df.loc[idx, '_als_signal_strength'],
+                )
             else:
-                w_adj, _ = _scale_weights_by_coverage(list(weights), g['als_norm'], g['lift_norm'], threshold=als_cov_thr)
+                w_adj, _ = _scale_weights_by_coverage(
+                    list(weights),
+                    g['als_norm'],
+                    g['lift_norm'],
+                    threshold=als_cov_thr,
+                    als_signal=g['_als_signal_strength'],
+                )
             sc = (
                 w_adj[0] * g['p_icp_pct'] +
                 w_adj[1] * g['lift_norm'] +
@@ -634,7 +670,13 @@ def rank_whitespace(inputs: RankInputs, *, weights: Iterable[float] = (0.60, 0.2
             ).astype(float)
             df.loc[idx, 'score'] = sc
     else:
-        w_adj, _ = _scale_weights_by_coverage(list(weights), df['als_norm'], df['lift_norm'], threshold=als_cov_thr)
+        w_adj, _ = _scale_weights_by_coverage(
+            list(weights),
+            df['als_norm'],
+            df['lift_norm'],
+            threshold=als_cov_thr,
+            als_signal=df['_als_signal_strength'],
+        )
         champion_score = (
             w_adj[0] * df['p_icp_pct'] +
             w_adj[1] * df['lift_norm'] +

--- a/gosales/tests/test_phase4_weight_scaling_and_als.py
+++ b/gosales/tests/test_phase4_weight_scaling_and_als.py
@@ -12,8 +12,9 @@ from gosales.pipeline.rank_whitespace import (
 def test_scale_weights_by_coverage_scales_and_normalizes():
     base = [0.6, 0.2, 0.1, 0.1]  # [p, lift, als, ev]
     lift = pd.Series([0.0]*8 + [0.9, 0.8])     # 20% coverage
-    als = pd.Series([0.0]*9 + [0.7])           # 10% coverage
-    w_adj, adj = _scale_weights_by_coverage(base, als, lift, threshold=0.3)
+    als = pd.Series([0.0]*9 + [0.7])           # 10% normalized coverage
+    als_signal = pd.Series([0.0]*9 + [1.0])    # Raw embedding availability
+    w_adj, adj = _scale_weights_by_coverage(base, als, lift, threshold=0.3, als_signal=als_signal)
     assert abs(sum(w_adj) - 1.0) < 1e-6
     # Both lift and als should be scaled down (coverage below threshold)
     assert adj.get('als_weight_factor', 1.0) < 1.0
@@ -27,10 +28,13 @@ def test_als_norm_fallback_centroid_prefers_owned_centroid():
         'als_f1': [1.0, 0.8, -0.5, 0.0],
         'owned_division_pre_cutoff': [True, True, False, False],
     })
-    s = _compute_als_norm(df, cfg=None)
+    s, raw = _compute_als_norm(df, cfg=None)
     # The first two (near centroid) should have higher normalized scores
     assert s.iloc[0] > s.iloc[2]
     assert s.iloc[1] > s.iloc[3]
+    # Owned rows should register raw signal
+    assert raw.iloc[0] > 0
+    assert raw.iloc[1] > 0
 
 
 def test_affinity_lift_consumption_prefers_higher_values():
@@ -51,5 +55,32 @@ def test_scores_nonzero_when_signals_zero_coverage():
     inputs = RankInputs(scores=df)
     result = rank_whitespace(inputs, weights=(0.0, 0.5, 0.5, 0.0))
     assert result["score"].sum() > 0
+
+
+def test_rank_whitespace_assets_fallback_for_sparse_als():
+    df = pd.DataFrame(
+        {
+            "division_name": ["A"] * 4,
+            "customer_id": ["c1", "c2", "c3", "c4"],
+            "icp_score": [0.2, 0.3, 0.4, 0.5],
+            "als_f0": [0.9, 0.0, 0.0, 0.0],
+            "als_f1": [0.8, 0.0, 0.0, 0.0],
+            "als_assets_f0": [0.5, 0.2, 0.1, 0.3],
+            "als_assets_f1": [0.4, 0.3, 0.2, 0.35],
+        }
+    )
+    _, raw = _compute_als_norm(df, cfg=None)
+    # Only the first row has ALS signal strength
+    assert raw.iloc[0] > 0 and raw.iloc[1:].eq(0).all()
+
+    inputs = RankInputs(scores=df)
+    result = rank_whitespace(inputs, weights=(0.0, 0.0, 1.0, 0.0))
+    res = result.set_index("customer_id")
+    # Rows without ALS embeddings should receive fallback scores
+    assert res.loc["c2", "als_norm"] > 0
+    assert res.loc["c3", "als_norm"] > 0
+    assert res.loc["c4", "als_norm"] > 0
+    # The true ALS row should remain competitive
+    assert res.loc["c1", "als_norm"] >= res.loc["c2", "als_norm"]
 
 


### PR DESCRIPTION
## Summary
- derive ALS coverage from raw embedding strength prior to percentile normalization
- ensure sparse or missing ALS rows trigger assets/item2vec fallbacks during ranking and weight scaling
- expand unit tests to capture new coverage metric and sparse embedding fallback behavior

## Testing
- PYTHONPATH=. pytest gosales/tests/test_phase4_weight_scaling_and_als.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d76eb371a4833388bf7e2e53504ccb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute ALS coverage from raw embedding strength, propagate it to weight scaling and ranking fallbacks, and update tests accordingly.
> 
> - **Pipeline**:
>   - **ALS computation**: `_compute_als_norm` now returns `(als_norm, als_signal_strength)`; handles missing/zero vectors, coerces numerics, selects centroid using valid rows, and sets similarities for invalid rows to 0.
>   - **Weight scaling**: `_scale_weights_by_coverage` accepts `als_signal` to compute ALS coverage independently of normalization.
>   - **Ranking**: `rank_whitespace` stores `_als_signal_strength`, computes ALS coverage from it, updates zero-signal masks, applies assets-ALS/item2vec fallbacks, and passes `als_signal` into weight scaling.
> - **Tests**:
>   - Update coverage scaling test to use `als_signal`.
>   - Adjust ALS norm test to consume tuple and assert raw signal presence.
>   - Add test ensuring assets-ALS fallback populates scores when ALS embeddings are sparse.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cd19230830c6ee8fce8a38ab92dd140e3cda6d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->