### PR TITLE
Normalize division string handling

### DIFF
--- a/gosales/etl/sku_map.py
+++ b/gosales/etl/sku_map.py
@@ -322,11 +322,14 @@ def get_model_targets(model: str) -> Tuple[str, ...]:
     """
     m = get_sku_mapping()
 
-    if model == "SWX_Seats":
+    model_key = (model or "").strip()
+    model_norm = model_key.casefold()
+
+    if model_norm == "swx_seats":
         return tuple(x for x in ("SWX_Core", "SWX_Pro_Prem") if x in m)
-    if model == "PDM_Seats":
+    if model_norm == "pdm_seats":
         return tuple(x for x in ("PDM", "EPDM_CAD_Editor_Seats") if x in m)
-    if model == "Printers":
+    if model_norm == "printers":
         # Include series/brands used in current and legacy naming that still roll up in data.
         # Consumables and Post_Processing are predictors, not positives, so they are intentionally excluded.
         printer_keys = (
@@ -342,21 +345,21 @@ def get_model_targets(model: str) -> Tuple[str, ...]:
             "_1200_Elite_Fortus250",
         )
         return tuple(x for x in printer_keys if x in m)
-    if model == "Services":
+    if model_norm == "services":
         return tuple(x for x in ("Services",) if x in m)
-    if model == "Success_Plan":
+    if model_norm == "success_plan":
         return tuple(x for x in ("Success_Plan",) if x in m)
-    if model == "Training":
+    if model_norm == "training":
         return tuple(x for x in ("Training",) if x in m)
-    if model == "Simulation":
+    if model_norm == "simulation":
         return tuple(x for x in ("Simulation", "SW_Plastics") if x in m)
-    if model == "Scanning":
+    if model_norm == "scanning":
         return tuple(x for x in ("Creaform", "Artec") if x in m)
-    if model == "CAMWorks":
+    if model_norm == "camworks":
         return tuple(x for x in ("CAMWorks_Seats",) if x in m)
-    if model == "SW_Electrical":
+    if model_norm == "sw_electrical":
         return tuple(x for x in ("SW_Electrical",) if x in m)
-    if model == "SW_Inspection":
+    if model_norm == "sw_inspection":
         return tuple(x for x in ("SW_Inspection",) if x in m)
     if model == "Post_Processing":
         return tuple(x for x in ("Post_Processing",) if x in m)

--- a/gosales/labels/targets.py
+++ b/gosales/labels/targets.py
@@ -62,13 +62,16 @@ def build_labels_for_division(
     # Window-period transactions for target division
     window_df = facts[(facts['order_date'] > cutoff_dt) & (facts['order_date'] <= win_end)].copy()
     # Normalize division string comparisons to avoid whitespace/case issues
-    window_df['product_division'] = window_df['product_division'].astype(str).str.strip()
+    window_df['product_division'] = (
+        window_df['product_division'].astype(str).str.strip().str.casefold()
+    )
     # Determine if caller passed a custom model (e.g., 'Printers'); if so, match by SKU set
-    sku_targets = tuple(get_model_targets(normalize_division(params.division)))
+    target_norm = normalize_division(params.division)
+    sku_targets = tuple(get_model_targets(target_norm))
     if sku_targets:
         window_target = window_df[window_df['product_sku'].astype(str).isin(sku_targets)].copy()
     else:
-        window_target = window_df[window_df['product_division'] == normalize_division(params.division)].copy()
+        window_target = window_df[window_df['product_division'] == target_norm].copy()
     # Optional denylist SKUs exclusion (e.g., trials/POC)
     try:
         cfg_obj = cfg.load_config()
@@ -107,8 +110,17 @@ def build_labels_for_division(
                 widened = min(int(params.max_window_months), widened + 3)
                 new_end = cutoff_dt + relativedelta(months=widened)
                 window_df_w = facts[(facts['order_date'] > cutoff_dt) & (facts['order_date'] <= new_end)].copy()
-                window_df_w['product_division'] = window_df_w['product_division'].astype(str).str.strip()
-                window_target_w = window_df_w[window_df_w['product_division'] == normalize_division(params.division)].copy()
+                window_df_w['product_division'] = (
+                    window_df_w['product_division'].astype(str).str.strip().str.casefold()
+                )
+                if sku_targets:
+                    window_target_w = window_df_w[
+                        window_df_w['product_sku'].astype(str).isin(sku_targets)
+                    ].copy()
+                else:
+                    window_target_w = window_df_w[
+                        window_df_w['product_division'] == target_norm
+                    ].copy()
                 labels = _compute_labels(window_target_w)
                 pos = int(labels['label'].sum()) if not labels.empty else 0
             # Update window_end if widened
@@ -117,7 +129,9 @@ def build_labels_for_division(
         pass
 
     # Cohorts from feature period
-    feature_df['product_division'] = feature_df['product_division'].astype(str).str.strip()
+    feature_df['product_division'] = (
+        feature_df['product_division'].astype(str).str.strip().str.casefold()
+    )
 
     had_any_df = (
         feature_df[['customer_id']]
@@ -135,7 +149,7 @@ def build_labels_for_division(
         )
     else:
         had_div_df = (
-            feature_df[feature_df['product_division'] == normalize_division(params.division)][['customer_id']]
+            feature_df[feature_df['product_division'] == target_norm][['customer_id']]
             .dropna()
             .drop_duplicates()
             .assign(had_div=1)

--- a/gosales/tests/test_discover_available_models.py
+++ b/gosales/tests/test_discover_available_models.py
@@ -38,5 +38,5 @@ def test_discover_available_models_preserves_casing(tmp_path):
     model_dir.mkdir()
 
     available = discover_available_models(models_root)
-    assert "Multi Word" in available
-    assert available["Multi Word"] == model_dir
+    assert "multi word" in available
+    assert available["multi word"] == model_dir

--- a/gosales/tests/test_features.py
+++ b/gosales/tests/test_features.py
@@ -55,6 +55,48 @@ def test_feature_cli_checksum(tmp_path, monkeypatch):
     assert result.exit_code == 0
 
 
+def test_feature_matrix_handles_mixed_case_division(tmp_path):
+    eng = create_engine(f"sqlite:///{tmp_path}/test_features_case.db")
+    fact = pd.DataFrame(
+        [
+            {
+                "customer_id": 1,
+                "order_date": "2024-01-10",
+                "product_division": "SOLIDWORKS",
+                "product_sku": "SWX_Core",
+                "gross_profit": 100,
+                "quantity": 1,
+            },
+            {
+                "customer_id": 1,
+                "order_date": "2024-02-05",
+                "product_division": "solidworks",
+                "product_sku": "SWX_Core",
+                "gross_profit": 50,
+                "quantity": 1,
+            },
+            {
+                "customer_id": 2,
+                "order_date": "2024-01-15",
+                "product_division": "services",
+                "product_sku": "Training",
+                "gross_profit": 20,
+                "quantity": 1,
+            },
+        ]
+    )
+    fact.to_sql("fact_transactions", eng, if_exists="replace", index=False)
+    pd.DataFrame({"customer_id": [1, 2]}).to_sql("dim_customer", eng, if_exists="replace", index=False)
+
+    fm = create_feature_matrix(
+        eng,
+        "sOlIdWoRkS",
+        cutoff_date="2024-01-31",
+        prediction_window_months=1,
+    )
+
+    pdf = fm.to_pandas()
+    assert int(pdf.loc[pdf["customer_id"] == 1, "bought_in_division"].iloc[0]) == 1
 def test_cli_config_override_persist(tmp_path, monkeypatch):
     out_dir = tmp_path / "out"
     monkeypatch.setattr("gosales.features.build.OUTPUTS_DIR", out_dir)

--- a/gosales/tests/test_labels.py
+++ b/gosales/tests/test_labels.py
@@ -78,3 +78,46 @@ def test_censoring_flag(tmp_path):
     assert int(pdf["censored_flag"].iloc[0]) in (0, 1)
 
 
+def test_build_labels_mixed_case_division(tmp_path):
+    eng = _make_engine(tmp_path)
+    fact = pd.DataFrame(
+        [
+            {
+                "customer_id": 1,
+                "order_date": "2024-03-01",
+                "product_division": "SOLIDWORKS",
+                "product_sku": "SWX_Core",
+                "gross_profit": 10,
+            },
+            {
+                "customer_id": 1,
+                "order_date": "2024-05-15",
+                "product_division": "solidworks",
+                "product_sku": "SWX_Core",
+                "gross_profit": 15,
+            },
+            {
+                "customer_id": 2,
+                "order_date": "2024-05-20",
+                "product_division": "Services",
+                "product_sku": "Training",
+                "gross_profit": 5,
+            },
+        ]
+    )
+    fact.to_sql("fact_transactions", eng, if_exists="replace", index=False)
+    pd.DataFrame({"customer_id": [1, 2]}).to_sql("dim_customer", eng, if_exists="replace", index=False)
+
+    params = LabelParams(
+        division="SOLIDWORKS",
+        cutoff="2024-04-30",
+        window_months=2,
+        mode="all",
+        gp_min_threshold=0.0,
+    )
+    df = build_labels_for_division(eng, params)
+    pdf = df.to_pandas()
+
+    assert int(pdf.loc[pdf["customer_id"] == 1, "label"].iloc[0]) == 1
+
+

--- a/gosales/tests/test_normalize.py
+++ b/gosales/tests/test_normalize.py
@@ -1,0 +1,7 @@
+from gosales.utils.normalize import normalize_division
+
+
+def test_normalize_division_casefolds_and_strips():
+    assert normalize_division("  SolidWorks  ") == "solidworks"
+    assert normalize_division("SW ELECTRICAL") == "sw electrical"
+    assert normalize_division(None) == ""

--- a/gosales/utils/normalize.py
+++ b/gosales/utils/normalize.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 def normalize_division(text: str | None) -> str:
     """Return a canonical division string for comparisons.
 
-    Currently minimal: trims surrounding whitespace and handles None safely.
+    The canonical form trims surrounding whitespace and applies ``casefold``
+    so downstream comparisons can be performed in a case-insensitive manner.
+    ``None`` inputs are converted to the empty string.
     """
-    return (text or "").strip()
+
+    return (text or "").strip().casefold()
 
 


### PR DESCRIPTION
## Summary
- casefold division normalization to ensure consistent comparisons across the pipeline
- update feature, label, and scoring utilities to compare divisions using the new canonical form
- add unit tests covering mixed-case division inputs for normalization, feature building, and label generation

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'gosales')*

------
https://chatgpt.com/codex/tasks/task_e_68d76ede68448333a96c2f6a8ebabd4f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make division handling case-insensitive by casefolding and updating comparisons in features, labels, scoring, and SKU model targets; add tests for mixed-case inputs.
> 
> - **Normalization**:
>   - Update `gosales/utils/normalize.normalize_division` to `strip().casefold()` and adopt canonical form everywhere.
> - **Features** (`gosales/features/engine.py`):
>   - Use lowercased `division_col` and canonical comparisons for targets, recency, returns, and past SolidWorks flags.
> - **Labels** (`gosales/labels/targets.py`):
>   - Case-normalize `product_division` in windows/feature cohorts; compare against `normalize_division(params.division)`; respect SKU-based targets during auto-widening.
> - **Scoring Pipeline** (`gosales/pipeline/score_customers.py`):
>   - Normalize discovered model keys and pruning/whitespace filters using canonical division names.
> - **ETL / SKU targets** (`gosales/etl/sku_map.py`):
>   - Accept case-insensitive logical model names in `get_model_targets` via `casefold()`.
> - **Tests**:
>   - Add `test_normalize_division_casefolds_and_strips` and mixed-case coverage for features/labels.
>   - Adjust model discovery test to expect normalized keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e5a84b6113b7765453df274abbcfd2635e0397e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->