### PR TITLE
fix(utils): reuse logger stream handler

### DIFF
--- a/gosales/tests/test_logger.py
+++ b/gosales/tests/test_logger.py
@@ -1,0 +1,26 @@
+import logging
+from uuid import uuid4
+
+from gosales.utils.logger import get_logger
+
+
+def test_get_logger_reuses_stream_handler():
+    logger_name = f"test_logger_{uuid4()}"
+
+    first_logger = get_logger(logger_name)
+    second_logger = get_logger(logger_name)
+
+    assert first_logger is second_logger
+
+    stream_handlers = [
+        handler for handler in first_logger.handlers if isinstance(handler, logging.StreamHandler)
+    ]
+    assert len(stream_handlers) == 1
+
+    handler = stream_handlers[0]
+    expected_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    assert handler.formatter is not None
+    assert handler.formatter._fmt == expected_format
+
+    for existing_handler in list(first_logger.handlers):
+        first_logger.removeHandler(existing_handler)

--- a/gosales/utils/logger.py
+++ b/gosales/utils/logger.py
@@ -20,18 +20,22 @@ def get_logger(name: str, level: int = logging.INFO) -> logging.Logger:
     logger = logging.getLogger(name)
     logger.setLevel(level)
 
-    # Create a handler
-    handler = logging.StreamHandler(sys.stdout)
-
-    # Create a formatter
+    # Create or reuse a handler
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
 
-    # Set the formatter for the handler
-    handler.setFormatter(formatter)
+    handler = None
+    for existing_handler in logger.handlers:
+        if isinstance(existing_handler, logging.StreamHandler):
+            handler = existing_handler
+            break
 
-    # Add the handler to the logger
-    logger.addHandler(handler)
+    if handler is None:
+        handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(handler)
+
+    # Ensure the handler uses the expected formatter configuration
+    handler.setFormatter(formatter)
 
     return logger


### PR DESCRIPTION
## Summary
- avoid adding duplicate stream handlers when requesting the same logger
- ensure the stream handler formatter remains consistent on reuse
- cover the reuse behavior with a focused unit test

## Testing
- python -m pytest gosales/tests/test_logger.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d76ef715c483338fc43a13d524da1c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `get_logger` to reuse an existing `StreamHandler` and ensure a consistent formatter; add a unit test validating handler reuse and formatting.
> 
> - **Utils**:
>   - Update `gosales/utils/logger.py` `get_logger` to reuse existing `logging.StreamHandler` if present, only add a new one when absent, and always set the expected formatter.
> - **Tests**:
>   - Add `gosales/tests/test_logger.py` to verify logger instance reuse, single `StreamHandler`, and correct formatter configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d3ff5ecc3ea303ba345e79fcbafccf18d8aecdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->