### PR TITLE
fix: guard lift metric against zero base rate

### DIFF
--- a/gosales/pipeline/validate_holdout.py
+++ b/gosales/pipeline/validate_holdout.py
@@ -39,8 +39,10 @@ def _lift_at_k(y_true: np.ndarray, y_score: np.ndarray, k_percent: int) -> float
     k = max(1, int(n * (k_percent / 100.0)))
     idx = np.argsort(-y_score, kind="stable")[:k]
     top_rate = float(np.mean(y_true[idx]))
-    base = float(np.mean(y_true)) if np.mean(y_true) > 0 else 1e-9
-    return top_rate / base
+    base_rate = float(np.mean(y_true))
+    if np.isclose(base_rate, 0.0):
+        return float("nan")
+    return top_rate / base_rate
 
 
 def validate_holdout(icp_scores_csv: str | Path, *, year_tag: str | None = None, gates: Dict[str, float] | None = None) -> Path:


### PR DESCRIPTION
## Summary
- update the holdout validation lift computation to return NaN when the base rate is zero
- rely on existing gate checks to skip lift-based gating when the result is NaN

## Testing
- pytest gosales/tests/test_phase3_metrics.py -q *(fails: ModuleNotFoundError: No module named 'gosales')*

------
https://chatgpt.com/codex/tasks/task_e_68d76fb2c2708333bd6f0918ba6e8353

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `validate_holdout._lift_at_k` to return NaN when base rate is effectively zero instead of dividing by a tiny epsilon.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6427a5922f41736c684de575b7a967e47d790a49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->