### PR TITLE
Compute type consistency score from sampled query results

### DIFF
--- a/gosales/tests/test_monitoring_data_collector.py
+++ b/gosales/tests/test_monitoring_data_collector.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from unittest.mock import MagicMock
+
+from gosales.monitoring.data_collector import MonitoringDataCollector
+
+
+def test_type_consistency_score_penalizes_inconsistent_types(monkeypatch):
+    collector = MonitoringDataCollector()
+
+    consistent_df = pd.DataFrame(
+        {
+            "source_table": ["dim_customer"] * 3 + ["fact_transactions"] * 3,
+            "customer_id": [1, 2, 3, 4, 5, 6],
+        }
+    )
+    inconsistent_df = pd.DataFrame(
+        {
+            "source_table": ["dim_customer", "dim_customer", "fact_transactions", "fact_transactions"],
+            "customer_id": [1, 2, 3, "4"],
+        }
+    )
+
+    monkeypatch.setattr(
+        "gosales.monitoring.data_collector.get_db_connection", lambda: object()
+    )
+    read_sql_mock = MagicMock(side_effect=[consistent_df, inconsistent_df])
+    monkeypatch.setattr(
+        "gosales.monitoring.data_collector.pd.read_sql_query", read_sql_mock
+    )
+
+    consistent_score = collector._calculate_type_consistency_score()
+    inconsistent_score = collector._calculate_type_consistency_score()
+
+    assert inconsistent_score < consistent_score
+    assert read_sql_mock.call_count == 2


### PR DESCRIPTION
## Summary
- execute the monitoring type-consistency probe against the database and derive the score from sampled customer IDs
- guard against empty samples and mixed-source anomalies while keeping the previous fallback defaults when checks cannot run
- add a unit test that mocks query results to ensure inconsistent types lower the computed score

## Testing
- pytest gosales/tests/test_monitoring_data_collector.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d99ec9c654833388953bfc7372c56a